### PR TITLE
feat: endpoint para atualizar o status do pedido

### DIFF
--- a/src/main/java/com/fiap/challenge/food/application/controller/OrderController.java
+++ b/src/main/java/com/fiap/challenge/food/application/controller/OrderController.java
@@ -7,15 +7,10 @@ import com.fiap.challenge.food.domain.model.order.Order;
 import com.fiap.challenge.food.domain.ports.inbound.OrderService;
 import com.fiap.challenge.food.infrastructure.mapper.PageResultMapper;
 import com.fiap.challenge.food.infrastructure.mapper.ViewMapper;
+import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
@@ -45,5 +40,11 @@ public class OrderController {
     ) {
         PageResult<Order> orderPage = orderService.getAllByStatus(statusFilter.getOrderStatuses(), page, size);
         return PageResultMapper.transformContent(orderPage, viewMapper::toOrderView);
+    }
+
+    @Transactional
+    @PatchMapping("/{id}/status/transition")
+    public void updateOrderStatus(@PathVariable Long id) {
+        orderService.updateStatus(id);
     }
 }

--- a/src/main/java/com/fiap/challenge/food/domain/model/order/OrderStatus.java
+++ b/src/main/java/com/fiap/challenge/food/domain/model/order/OrderStatus.java
@@ -1,13 +1,42 @@
 package com.fiap.challenge.food.domain.model.order;
 
+import com.fiap.challenge.food.domain.model.exception.UnprocessableEntityException;
+
 import java.util.List;
 
 public enum OrderStatus {
-    WAITING_PAYMENT,
-    READY_FOR_PREPARATION,
-    IN_PREPARATION,
-    READY_FOR_PICKUP,
-    FINISHED;
+    WAITING_PAYMENT {
+        @Override
+        public OrderStatus next() {
+            return READY_FOR_PREPARATION;
+        }
+    },
+    READY_FOR_PREPARATION {
+        @Override
+        public OrderStatus next() {
+            return IN_PREPARATION;
+        }
+    },
+    IN_PREPARATION {
+        @Override
+        public OrderStatus next() {
+            return READY_FOR_PICKUP;
+        }
+    },
+    READY_FOR_PICKUP {
+        @Override
+        public OrderStatus next() {
+            return FINISHED;
+        }
+    },
+    FINISHED {
+        @Override
+        public OrderStatus next() {
+            throw new UnprocessableEntityException("No next status available for FINISHED orders.", "INVALID_ORDER_TRANSITION");
+        }
+    };
+
+    public abstract OrderStatus next();
 
     public static List<OrderStatus> getInProgressStatuses() {
         return List.of(READY_FOR_PREPARATION, IN_PREPARATION, READY_FOR_PICKUP);

--- a/src/main/java/com/fiap/challenge/food/domain/ports/inbound/OrderService.java
+++ b/src/main/java/com/fiap/challenge/food/domain/ports/inbound/OrderService.java
@@ -13,4 +13,6 @@ public interface OrderService {
     public void approvePayment(String transactionId);
 
     public void approvePayment(Long orderId);
+
+    public void updateStatus(Long orderId);
 }

--- a/src/test/java/com/fiap/challenge/food/application/controller/OrderControllerTest.java
+++ b/src/test/java/com/fiap/challenge/food/application/controller/OrderControllerTest.java
@@ -2,8 +2,10 @@ package com.fiap.challenge.food.application.controller;
 
 import com.fiap.challenge.food.application.request.OrderStatusFilter;
 import com.fiap.challenge.food.domain.model.PageResult;
+import com.fiap.challenge.food.domain.model.exception.UnprocessableEntityException;
 import com.fiap.challenge.food.domain.model.order.Order;
 import com.fiap.challenge.food.domain.ports.inbound.OrderService;
+import com.fiap.challenge.food.domain.ports.outbound.OrderRepository;
 import com.fiap.challenge.food.fixture.OrderFixture;
 import com.fiap.challenge.food.fixture.OrderViewFixture;
 import com.fiap.challenge.food.infrastructure.mapper.ViewMapper;
@@ -23,8 +25,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,4 +116,14 @@ class OrderControllerTest {
             )
             .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void patchOrderTransitionReturnsOk() throws Exception {
+        long orderId = 1L;
+        mockMvc.perform(MockMvcRequestBuilders.patch("/orders/{orderId}/status/transition", orderId))
+            .andExpect(status().isOk());
+
+        verify(orderService).updateStatus(orderId);
+    }
+
 }


### PR DESCRIPTION
Atualizar o status do pedido.
1. Todo fluxo do pedido deve ser atualizado, tal informação deverá ser utilizada pela cozinha, garantindo que nenhum pedido seja perdido, e que a cozinha possa iniciar a preparação após o pagamento.